### PR TITLE
Bugfix/settings window level

### DIFF
--- a/Overview/Overlay/Views/EditIndicatorOverlay.swift
+++ b/Overview/Overlay/Views/EditIndicatorOverlay.swift
@@ -36,6 +36,7 @@ struct EditIndicatorOverlay: View {
             Image(systemName: "righttriangle.fill")
                 .font(.caption)
                 .foregroundColor(focusBorderColor)
+                .offset(x: 0.5)
         }
     }
 }

--- a/Overview/Settings/SettingsView.swift
+++ b/Overview/Settings/SettingsView.swift
@@ -63,6 +63,7 @@ struct SettingsView: View {
                 $0.styleMask.rawValue == settingsStyleMask
             }) {
                 settingsWindow.level = .statusBar + 2
+                settingsWindow.collectionBehavior = [.managed]
             }
         }
     }


### PR DESCRIPTION
Settings window now appears in expose.

Note, if in the future we create windows that require the window level to be anything higher than .normal, we can use this fix (setting NSWindow collection behavior to managed) to ensure those windows appear in expose.