### PR TITLE
Feature/window title position toggle

### DIFF
--- a/Overview/Overlay/Settings/OverlaySettingsContent.swift
+++ b/Overview/Overlay/Settings/OverlaySettingsContent.swift
@@ -44,6 +44,11 @@ extension InfoPopoverContent {
                 text:
                     "Control title backdrop visibility. Higher opacity values improve text legibility but obstruct preview content."
             ),
+            Section(
+                title: "Location",
+                text:
+                    "Control title location on previews. Upper places the title at the top of the preview, while lower places it on the bottom of the preview."
+            ),
         ],
         isWarning: false
     )

--- a/Overview/Overlay/Settings/OverlaySettingsKeys.swift
+++ b/Overview/Overlay/Settings/OverlaySettingsKeys.swift
@@ -14,6 +14,7 @@ enum OverlaySettingsKeys {
     static let focusBorderWidth: String = "focusBorderWidth"
     static let focusBorderColor: String = "focusBorderColor"
     static let sourceTitleEnabled: String = "showWindowTitle"
+    static let sourceTitleLocation: String = "windowTitleLocation"
     static let sourceTitleFontSize: String = "titleFontSize"
     static let sourceTitleBackgroundOpacity: String = "titleBackgroundOpacity"
 
@@ -24,6 +25,7 @@ enum OverlaySettingsKeys {
         let focusBorderWidth: Double = 5.0
         let focusBorderColor: Color = .gray
         let sourceTitleEnabled: Bool = true
+        let sourceTitleLocation: Bool = true
         let sourceTitleFontSize: Double = 12.0
         let sourceTitleBackgroundOpacity: Double = 0.4
 

--- a/Overview/Overlay/Settings/OverlaySettingsTab.swift
+++ b/Overview/Overlay/Settings/OverlaySettingsTab.swift
@@ -28,6 +28,8 @@ struct OverlaySettingsTab: View {
     @AppStorage(OverlaySettingsKeys.sourceTitleBackgroundOpacity)
     private var sourceTitleBackgroundOpacity = OverlaySettingsKeys.defaults
         .sourceTitleBackgroundOpacity
+    @AppStorage(OverlaySettingsKeys.sourceTitleLocation)
+    private var sourceTitleLocation = OverlaySettingsKeys.sourceTitleLocation
 
     var body: some View {
         Form {
@@ -103,6 +105,14 @@ struct OverlaySettingsTab: View {
                         Text("\(Int(sourceTitleBackgroundOpacity * 100))%")
                             .foregroundColor(.secondary)
                             .frame(width: 40)
+                    }
+                    HStack {
+                        Picker("Location", selection: $sourceTitleLocation) {
+                            Text("Upper").tag(true)
+                            Text("Lower").tag(false)
+                        }
+                        .pickerStyle(.segmented)
+
                     }
                 }
             }

--- a/Overview/Overlay/Settings/OverlaySettingsTab.swift
+++ b/Overview/Overlay/Settings/OverlaySettingsTab.swift
@@ -29,7 +29,7 @@ struct OverlaySettingsTab: View {
     private var sourceTitleBackgroundOpacity = OverlaySettingsKeys.defaults
         .sourceTitleBackgroundOpacity
     @AppStorage(OverlaySettingsKeys.sourceTitleLocation)
-    private var sourceTitleLocation = OverlaySettingsKeys.sourceTitleLocation
+    private var sourceTitleLocation = OverlaySettingsKeys.defaults.sourceTitleLocation
 
     var body: some View {
         Form {

--- a/Overview/Overlay/Views/TitleOverlay.swift
+++ b/Overview/Overlay/Views/TitleOverlay.swift
@@ -54,9 +54,15 @@ private struct TitleContainerView: View {
 
     var body: some View {
         VStack {
-            titleBar
-            Spacer()
+            if sourceTitleLocation {
+                titleBar
+                Spacer()
+            } else {
+                Spacer()
+                titleBar
+            }
         }
+        .padding(5)
     }
 
     // MARK: - Private Views
@@ -66,7 +72,7 @@ private struct TitleContainerView: View {
             titleText
             Spacer()
         }
-        .padding(6)
+        .padding(5)
     }
 
     private var titleText: some View {

--- a/Overview/Overlay/Views/TitleOverlay.swift
+++ b/Overview/Overlay/Views/TitleOverlay.swift
@@ -22,6 +22,8 @@ struct TitleOverlay: View {
     @AppStorage(OverlaySettingsKeys.sourceTitleBackgroundOpacity)
     private var sourceTitleBackgroundOpacity = OverlaySettingsKeys.defaults
         .sourceTitleBackgroundOpacity
+    @AppStorage(OverlaySettingsKeys.sourceTitleLocation)
+    private var sourceTitleLocation = OverlaySettingsKeys.defaults.sourceTitleLocation
 
     var body: some View {
         Group {
@@ -37,7 +39,8 @@ struct TitleOverlay: View {
         TitleContainerView(
             title: title,
             fontSize: sourceTitleFontSize,
-            backgroundOpacity: sourceTitleBackgroundOpacity
+            backgroundOpacity: sourceTitleBackgroundOpacity,
+            sourceTitleLocation: sourceTitleLocation
         )
     }
 }
@@ -47,6 +50,7 @@ private struct TitleContainerView: View {
     let title: String
     let fontSize: Double
     let backgroundOpacity: Double
+    let sourceTitleLocation: Bool
 
     var body: some View {
         VStack {

--- a/Overview/Settings/SettingsManager.swift
+++ b/Overview/Settings/SettingsManager.swift
@@ -85,6 +85,9 @@ final class SettingsManager: ObservableObject {
         UserDefaults.standard.set(
             OverlaySettingsKeys.defaults.sourceTitleBackgroundOpacity,
             forKey: OverlaySettingsKeys.sourceTitleBackgroundOpacity)
+        UserDefaults.standard.set(
+            OverlaySettingsKeys.defaults.sourceTitleLocation,
+            forKey: OverlaySettingsKeys.sourceTitleLocation)
 
         /// Reset Preview settings
         UserDefaults.standard.set(


### PR DESCRIPTION
I had meant to rope this upgrade in with a few others, but since it's done, I figured we could add it to the dev branch.

- Added toggle under window settings to select window title location (upper or lower), added relevant defaults
- Changed padding slightly to move window titles closer to the corners of previews