### PR TITLE
Fix preview interaction

### DIFF
--- a/Overview/Overlay/Views/CloseButtonOverlay.swift
+++ b/Overview/Overlay/Views/CloseButtonOverlay.swift
@@ -15,12 +15,13 @@ struct CloseButtonOverlay: View {
 
     // Public Properties
     let isEditModeEnabled: Bool
+    let isSelectionViewVisible: Bool
     let teardownCapture: () async -> Void
     let onClose: () -> Void
 
     var body: some View {
         Group {
-            if isEditModeEnabled {
+            if isEditModeEnabled || isSelectionViewVisible {
                 VStack {
                     HStack {
                         Spacer()

--- a/Overview/Preview/PreviewView.swift
+++ b/Overview/Preview/PreviewView.swift
@@ -59,6 +59,7 @@ struct PreviewView: View {
                 .overlay(
                     CloseButtonOverlay(
                         isEditModeEnabled: previewManager.editModeEnabled,
+                        isSelectionViewVisible: isSelectionViewVisible,
                         teardownCapture: teardownCapture,
                         onClose: onClose
                     )

--- a/Overview/Preview/PreviewView.swift
+++ b/Overview/Preview/PreviewView.swift
@@ -52,9 +52,9 @@ struct PreviewView: View {
             previewContentStack(in: geometry)
                 .frame(width: geometry.size.width, height: geometry.size.height)
                 .aspectRatio(previewAspectRatio, contentMode: .fit)
+                .background(previewInteractionLayer)
                 .background(previewBackgroundLayer)
                 .background(windowConfigurationLayer)
-                .overlay(previewInteractionLayer)
                 .overlay(EditIndicatorOverlay(isEditModeEnabled: previewManager.editModeEnabled))
                 .overlay(
                     CloseButtonOverlay(

--- a/Overview/Shortcut/Settings/ShortcutSettingsTab.swift
+++ b/Overview/Shortcut/Settings/ShortcutSettingsTab.swift
@@ -147,7 +147,7 @@ struct ShortcutSettingsTab: View {
             }
         }
         .formStyle(.grouped)
-        .task { await refreshSourceList() }
+        .task { refreshSourceList() }
         .alert("Delete Shortcut", isPresented: $showingDeleteAlert) {
             Button("Cancel", role: .cancel) {}
             Button("Delete", role: .destructive) {

--- a/Overview/Window/WindowInteraction.swift
+++ b/Overview/Window/WindowInteraction.swift
@@ -103,17 +103,7 @@ private final class WindowInteractionHandler: NSView, NSMenuDelegate {
         editModeItem.state = editModeEnabled ? .on : .off
         stopCaptureItem.isEnabled = !isSelectionVisible
     }
-
-    override func hitTest(_ point: NSPoint) -> NSView? {
-        // Allow underlying SwiftUI views to receive events when the selection
-        // interface is visible. Beta 3 changed event propagation behavior so
-        // simply calling `super.mouseDown` no longer forwarded clicks through
-        // this overlay. Returning nil when the selection view is active lets
-        // dropdowns and buttons remain interactive.
-        if isSelectionVisible { return nil }
-        return super.hitTest(point)
-    }
-
+    
     override func mouseDown(with event: NSEvent) {
         if !editModeEnabled && !isSelectionVisible {
             onSourceWindowFocus?()


### PR DESCRIPTION
- Added close button to selection view regardless of edit mode state
- Fixed context menu being inaccessible due to preview beta 3 fix overriding interactions for preview stack
<br>

- [x] Tested on macOS Tahoe 26 Beta 3
- [ ] Tested on macOS Sequoia 16